### PR TITLE
fix wrong detection for pid exist checking

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -203,7 +203,7 @@ FORCE_SERVER: {
         Rex::Logger::debug("Found $::rexfile.lock");
         my $pid = eval { local ( @ARGV, $/ ) = ("$::rexfile.lock"); <>; };
         system(
-          "ps aux | awk -F' ' ' { print \$2 } ' | grep $pid >/dev/null 2>&1");
+          "ps aux | awk -F' ' ' { print \$2 } ' | grep '^$pid\$' >/dev/null 2>&1");
         if ( $? == 0 ) {
           Rex::Logger::info("Rexfile is in use by $pid.");
           CORE::exit 1;


### PR DESCRIPTION
for example
there is a pid 1492 in system  
and the previous rex pid is 492 , without this patch , I will detect Rexfile is in use by 492.
